### PR TITLE
Fix type of 'use_ws_proxy' in configuration files

### DIFF
--- a/hydra.example.json
+++ b/hydra.example.json
@@ -2,7 +2,7 @@
 	"hydraplay": {
 		"port": 8080,
 		"source_type": "tcp",
-		"use_ws_proxy": "false",
+		"use_ws_proxy": false,
 		"cookie_secret": "_GENERATE_YOUR_OWN_RANDOM_VALUE_HERE__"
 	},
 	"mopidy":{

--- a/src/config/hydra.config.json
+++ b/src/config/hydra.config.json
@@ -2,7 +2,7 @@
 	"hydraplay": {
 	    "port": 8080,
 		"source_type": "tcp",
-		"use_ws_proxy": "false",
+		"use_ws_proxy": false,
 		"cookie_secret": "_GENERATE_YOUR_OWN_RANDOM_VALUE_HERE__"
 	},
 	"mopidy":{

--- a/src/hydraplay/config/hydra.config.json
+++ b/src/hydraplay/config/hydra.config.json
@@ -2,7 +2,7 @@
 	"hydraplay": {
 	    "port": 8080,
 		"source_type": "tcp",
-		"use_ws_proxy": "false",
+		"use_ws_proxy": false,
 		"cookie_secret": "_GENERATE_YOUR_OWN_RANDOM_VALUE_HERE__"
 	},
 	"mopidy":{


### PR DESCRIPTION
Fix type of 'use_ws_proxy' in config files to match usage in code